### PR TITLE
Fix purchasing AAs on Emu

### DIFF
--- a/MQ2AASpend.cpp
+++ b/MQ2AASpend.cpp
@@ -447,7 +447,7 @@ void SpendAAFromINI()
 					if (!bDebug)
 					{
 						char szCommand[MAX_BUYLINE] = { 0 };
-#if (IS_EMU_CLIENT)
+#if !IS_EXPANSION_LEVEL(EXPANSION_LEVEL_COTF)
 						sprintf_s(szCommand, "/alt buy %d", pAbility->Index);
 #else
 						sprintf_s(szCommand, "/alt buy %d", pAbility->GroupID);
@@ -575,7 +575,7 @@ bool BuySingleAA(CAltAbilityData* pAbility)
 		if (!bDebug)
 		{
 			char szCommand[MAX_BUYLINE] = { 0 };
-#if (IS_EMU_CLIENT)
+#if !IS_EXPANSION_LEVEL(EXPANSION_LEVEL_COTF)
 			sprintf_s(szCommand, "/alt buy %d", pAbility->Index);
 #else
 			sprintf_s(szCommand, "/alt buy %d", pAbility->GroupID);

--- a/MQ2AASpend.cpp
+++ b/MQ2AASpend.cpp
@@ -447,7 +447,11 @@ void SpendAAFromINI()
 					if (!bDebug)
 					{
 						char szCommand[MAX_BUYLINE] = { 0 };
+#if (IS_EMU_CLIENT)
+						sprintf_s(szCommand, "/alt buy %d", pAbility->Index);
+#else
 						sprintf_s(szCommand, "/alt buy %d", pAbility->GroupID);
+#endif
 
 						DoCommand(pLocalPlayer, szCommand);
 					}
@@ -571,7 +575,11 @@ bool BuySingleAA(CAltAbilityData* pAbility)
 		if (!bDebug)
 		{
 			char szCommand[MAX_BUYLINE] = { 0 };
+#if (IS_EMU_CLIENT)
+			sprintf_s(szCommand, "/alt buy %d", pAbility->Index);
+#else
 			sprintf_s(szCommand, "/alt buy %d", pAbility->GroupID);
+#endif
 
 			DoCommand(pLocalPlayer, szCommand);
 		}


### PR DESCRIPTION
As mentioned in the issue - EMU uses index, not ID/GroupID to buy AAs. 

Resolves #4 